### PR TITLE
updating lpInvariant when lpTokenBalance changes in short strategy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gammaswap/v1-strategies",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "description": "Strategies contracts for the v1-core",
   "homepage": "https://gammaswap.com",
   "main": "index.js",

--- a/test/strategies/base/ShortStrategy.test.ts
+++ b/test/strategies/base/ShortStrategy.test.ts
@@ -600,10 +600,15 @@ describe("ShortStrategy", function () {
         expect(poolUpdatedEvent.args.lastBlockNumber).to.equal(
           (await ethers.provider.getBlock("latest")).number
         );
+
+        const cfmmBalance = await cfmm.balanceOf(strategy.address);
+        const cfmmTotalSupply = await cfmm.totalSupply();
+        const cfmmInvariant = await cfmm.invariant();
+        const lpInvariant = cfmmBalance.mul(cfmmInvariant).div(cfmmTotalSupply);
         expect(poolUpdatedEvent.args.accFeeIndex).to.equal(ONE);
         expect(poolUpdatedEvent.args.lastFeeIndex).to.equal(ONE);
         expect(poolUpdatedEvent.args.lpTokenBorrowedPlusInterest).to.equal(0);
-        expect(poolUpdatedEvent.args.lpInvariant).to.equal(0);
+        expect(poolUpdatedEvent.args.lpInvariant).to.equal(lpInvariant);
         expect(poolUpdatedEvent.args.borrowedInvariant).to.equal(0);
 
         expect(await strategy.totalSupply()).to.equal(expectedGSShares);
@@ -860,7 +865,12 @@ describe("ShortStrategy", function () {
         expect(poolUpdatedEvent.args.accFeeIndex).to.equal(ONE);
         expect(poolUpdatedEvent.args.lastFeeIndex).to.equal(ONE);
         expect(poolUpdatedEvent.args.lpTokenBorrowedPlusInterest).to.equal(0);
-        expect(poolUpdatedEvent.args.lpInvariant).to.equal(0);
+
+        const cfmmBalance = await cfmm.balanceOf(strategy.address);
+        const cfmmTotalSupply = await cfmm.totalSupply();
+        const cfmmInvariant = await cfmm.invariant();
+        const lpInvariant = cfmmBalance.mul(cfmmInvariant).div(cfmmTotalSupply);
+        expect(poolUpdatedEvent.args.lpInvariant).to.equal(lpInvariant);
         expect(poolUpdatedEvent.args.borrowedInvariant).to.equal(0);
 
         const depositReserveEvent = res.events[res.events.length - 1];

--- a/test/strategies/base/ShortStrategyERC4626.test.ts
+++ b/test/strategies/base/ShortStrategyERC4626.test.ts
@@ -463,10 +463,14 @@ describe("ShortStrategyERC4626", function () {
         expect(poolUpdatedEvent.args.lastBlockNumber).to.equal(
           (await ethers.provider.getBlock("latest")).number
         );
+        const cfmmBalance = await cfmm.balanceOf(strategy.address);
+        const cfmmTotalSupply = await cfmm.totalSupply();
+        const cfmmInvariant = await cfmm.invariant();
+        const lpInvariant = cfmmBalance.mul(cfmmInvariant).div(cfmmTotalSupply);
         expect(poolUpdatedEvent.args.accFeeIndex).to.equal(ONE);
         expect(poolUpdatedEvent.args.lastFeeIndex).to.equal(ONE);
         expect(poolUpdatedEvent.args.lpTokenBorrowedPlusInterest).to.equal(0);
-        expect(poolUpdatedEvent.args.lpInvariant).to.equal(0);
+        expect(poolUpdatedEvent.args.lpInvariant).to.equal(lpInvariant);
         expect(poolUpdatedEvent.args.borrowedInvariant).to.equal(0);
 
         expect(await strategy.totalSupply()).to.equal(expectedGSShares);
@@ -631,10 +635,14 @@ describe("ShortStrategyERC4626", function () {
         expect(poolUpdatedEvent.args.lastBlockNumber).to.equal(
           (await ethers.provider.getBlock("latest")).number
         );
+        const cfmmBalance = await cfmm.balanceOf(strategy.address);
+        const cfmmTotalSupply = await cfmm.totalSupply();
+        const cfmmInvariant = await cfmm.invariant();
+        const lpInvariant = cfmmBalance.mul(cfmmInvariant).div(cfmmTotalSupply);
         expect(poolUpdatedEvent.args.accFeeIndex).to.equal(ONE);
         expect(poolUpdatedEvent.args.lastFeeIndex).to.equal(ONE);
         expect(poolUpdatedEvent.args.lpTokenBorrowedPlusInterest).to.equal(0);
-        expect(poolUpdatedEvent.args.lpInvariant).to.equal(0);
+        expect(poolUpdatedEvent.args.lpInvariant).to.equal(lpInvariant);
         expect(poolUpdatedEvent.args.borrowedInvariant).to.equal(0);
 
         expect(await strategy.totalSupply()).to.equal(shares);


### PR DESCRIPTION
Updating LP_INVARIANT with correct numbers from CFMM when LP_TOKEN_BALANCE changes. Updated unit tests to reflect this change also.