### PR TITLE
update repayLiquidityWithLP with changes from v1-core

### DIFF
--- a/contracts/test/strategies/cpmm/TestCPMMRepayStrategy.sol
+++ b/contracts/test/strategies/cpmm/TestCPMMRepayStrategy.sol
@@ -91,8 +91,7 @@ contract TestCPMMRepayStrategy is CPMMRepayStrategy, BorrowStrategy {
     function _increaseCollateral(uint256, uint256[] calldata) external virtual override returns(uint128[] memory collateral) {
     }
 
-    function _repayLiquidityWithLP(uint256 tokenId, uint256 payLiquidity, uint256 collateralId, address to) external virtual override returns(uint256 liquidityPaid) {
-        return 0;
+    function _repayLiquidityWithLP(uint256 tokenId, uint256 collateralId, address to) external virtual override returns(uint256 liquidityPaid, uint128[] memory tokensHeld) {
     }
 
     function _repayLiquiditySetRatio(uint256 tokenId, uint256 payLiquidity, uint256[] calldata fees, uint256[] calldata ratio) external virtual override returns(uint256 liquidityPaid, uint256[] memory amounts) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gammaswap/v1-implementations",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Pool and strategies implementation contracts for GammaSwap",
   "homepage": "https://gammaswap.com",
   "main": "index.js",
@@ -72,7 +72,7 @@
     "@balancer-labs/v2-pool-weighted": "^2.0.1",
     "@balancer-labs/v2-solidity-utils": "^3.0.1",
     "@balancer-labs/v2-vault": "^3.0.1",
-    "@gammaswap/v1-core": "^0.5.15",
+    "@gammaswap/v1-core": "^0.5.16",
     "@openzeppelin/contracts": "^4.7.0",
     "@prb/math": "^3.1.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -555,10 +555,10 @@
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
 
-"@gammaswap/v1-core@^0.5.15":
-  version "0.5.15"
-  resolved "https://npm.pkg.github.com/download/@gammaswap/v1-core/0.5.15/2fa644f2f8442982cba9a8dd32908df40991a309#2fa644f2f8442982cba9a8dd32908df40991a309"
-  integrity sha512-9SAsX3Q+B5iyUvH4S2/DmoV+rbjVgeI2lx7qYAgi//f8ItutmmCfe25tefqQ7kx0/7EYqcNqvXbv0EVp9VJgKA==
+"@gammaswap/v1-core@^0.5.16":
+  version "0.5.16"
+  resolved "https://npm.pkg.github.com/download/@gammaswap/v1-core/0.5.16/6a19010e032ee2e7db69b144b5fc2cf9e9d4994c#6a19010e032ee2e7db69b144b5fc2cf9e9d4994c"
+  integrity sha512-aPvuqmYZa+OV1iDSUTSdSo3PODqhz08+kUCYSLuPAtMIDYXJv9awnfTW5c6Tb3Zal/7VGyEaYnqpleU6si0T4A==
   dependencies:
     "@openzeppelin/contracts" "^4.7.0"
 


### PR DESCRIPTION
update repayLiquidityWithLP with changes from v1-core in RepayStrategy. Change was to remove liquidity argument from the method signature and return updated tokensHeld.