### PR TITLE
Feat: Use LinearKinkedRateModel for CPMMGammaPool

### DIFF
--- a/contracts/strategies/cpmm/CPMMShortStrategy.sol
+++ b/contracts/strategies/cpmm/CPMMShortStrategy.sol
@@ -15,9 +15,9 @@ contract CPMMShortStrategy is CPMMBaseStrategy, ShortStrategySync {
     error NotOptimalDeposit();
     error ZeroReserves();
 
-    /// @dev Initializes the contract by setting `MAX_TOTAL_APY`, `BLOCKS_PER_YEAR`, `baseRate`, `factor`, and `maxApy`
-    constructor(uint256 maxTotalApy_, uint256 blocksPerYear_, uint64 baseRate_, uint80 factor_, uint80 maxApy_)
-        CPMMBaseStrategy(maxTotalApy_, blocksPerYear_, baseRate_, factor_, maxApy_) {
+    /// @dev Initializes the contract by setting `MAX_TOTAL_APY`, `BLOCKS_PER_YEAR`, `baseRate`, `optimalUtilRate`, `slope1`, and `slope2`
+    constructor(uint256 maxTotalApy_, uint256 blocksPerYear_, uint64 baseRate_, uint64 optimalUtilRate_, uint64 slope1_, uint64 slope2_)
+        CPMMBaseStrategy(maxTotalApy_, blocksPerYear_, baseRate_, optimalUtilRate_, slope1_, slope2_) {
     }
 
     /// @dev See {IShortStrategy-_getLatestCFMMReserves}.

--- a/contracts/strategies/cpmm/base/CPMMBaseLongStrategy.sol
+++ b/contracts/strategies/cpmm/base/CPMMBaseLongStrategy.sol
@@ -19,21 +19,22 @@ abstract contract CPMMBaseLongStrategy is BaseLongStrategy, CPMMBaseStrategy {
     address immutable public feeSource;
 
     /// @return tradingFee1 - numerator in tradingFee calculation (e.g amount * tradingFee1 / tradingFee2)
-    uint16 immutable public tradingFee1;
+    uint24 immutable public tradingFee1;
 
     /// @return tradingFee2 - denominator in tradingFee calculation (e.g amount * tradingFee1 / tradingFee2)
-    uint16 constant public tradingFee2 = 1e3;
+    uint24 immutable public tradingFee2 ;
 
     /// @return Returns the minimum liquidity payment amount.
     uint256 constant public MIN_PAY = 1e3;
 
-    /// @dev Initializes the contract by setting `MAX_TOTAL_APY`, `BLOCKS_PER_YEAR`, `tradingFee1`, `feeSource`,
-    /// @dev `baseRate`, `optimalUtilRate`, `slope1`, and `slope2`
-    constructor(uint256 maxTotalApy_, uint256 blocksPerYear_, uint16 tradingFee1_, address _feeSource, uint64 baseRate_,
-        uint64 optimalUtilRate_, uint64 slope1_, uint64 slope2_) CPMMBaseStrategy(maxTotalApy_, blocksPerYear_, baseRate_,
-        optimalUtilRate_, slope1_, slope2_) {
-        if(tradingFee1_ > tradingFee2) revert InvalidTradingFee();
+    /// @dev Initializes the contract by setting `MAX_TOTAL_APY`, `BLOCKS_PER_YEAR`, `tradingFee1`, `tradingFee2`,
+    /// @dev `feeSource`, `baseRate`, `optimalUtilRate`, `slope1`, and `slope2`
+    constructor(uint256 maxTotalApy_, uint256 blocksPerYear_, uint24 tradingFee1_, uint24 tradingFee2_, address _feeSource,
+        uint64 baseRate_, uint64 optimalUtilRate_, uint64 slope1_, uint64 slope2_) CPMMBaseStrategy(maxTotalApy_,
+        blocksPerYear_, baseRate_, optimalUtilRate_, slope1_, slope2_) {
+        if(tradingFee1_ > tradingFee2_) revert InvalidTradingFee();
         tradingFee1 = tradingFee1_;
+        tradingFee2 = tradingFee2_;
         feeSource = _feeSource;
     }
 
@@ -182,7 +183,7 @@ abstract contract CPMMBaseLongStrategy is BaseLongStrategy, CPMMBaseStrategy {
         return (reserveOut * amountIn * tradingFee2 / denominator) + 1;
     }
 
-    function getTradingFee1() internal view returns(uint16) {
-        return feeSource == address(0) ? tradingFee1 : 1000 - IFeeSource(feeSource).gsFee();
+    function getTradingFee1() internal view returns(uint24) {
+        return feeSource == address(0) ? tradingFee1 : tradingFee2 - IFeeSource(feeSource).gsFee();
     }
 }

--- a/contracts/strategies/cpmm/base/CPMMBaseLongStrategy.sol
+++ b/contracts/strategies/cpmm/base/CPMMBaseLongStrategy.sol
@@ -27,10 +27,11 @@ abstract contract CPMMBaseLongStrategy is BaseLongStrategy, CPMMBaseStrategy {
     /// @return Returns the minimum liquidity payment amount.
     uint256 constant public MIN_PAY = 1e3;
 
-    /// @dev Initializes the contract by setting `MAX_TOTAL_APY`, `BLOCKS_PER_YEAR`, `tradingFee1`, `tradingFee2`,
-    /// @dev `baseRate`, `factor`, and `maxApy`
+    /// @dev Initializes the contract by setting `MAX_TOTAL_APY`, `BLOCKS_PER_YEAR`, `tradingFee1`, `feeSource`,
+    /// @dev `baseRate`, `optimalUtilRate`, `slope1`, and `slope2`
     constructor(uint256 maxTotalApy_, uint256 blocksPerYear_, uint16 tradingFee1_, address _feeSource, uint64 baseRate_,
-        uint80 factor_, uint80 maxApy_) CPMMBaseStrategy(maxTotalApy_, blocksPerYear_, baseRate_, factor_, maxApy_) {
+        uint64 optimalUtilRate_, uint64 slope1_, uint64 slope2_) CPMMBaseStrategy(maxTotalApy_, blocksPerYear_, baseRate_,
+        optimalUtilRate_, slope1_, slope2_) {
         if(tradingFee1_ > tradingFee2) revert InvalidTradingFee();
         tradingFee1 = tradingFee1_;
         feeSource = _feeSource;

--- a/contracts/strategies/cpmm/base/CPMMBaseRebalanceStrategy.sol
+++ b/contracts/strategies/cpmm/base/CPMMBaseRebalanceStrategy.sol
@@ -19,10 +19,10 @@ abstract contract CPMMBaseRebalanceStrategy is BaseRebalanceStrategy, CPMMBaseLo
     address immutable public mathLib;
 
     /// @dev Initializes the contract by setting `mathLib`, `MAX_TOTAL_APY`, `BLOCKS_PER_YEAR`, `tradingFee1`,
-    /// @dev `feeSource_`, `baseRate`, `factor`, and `maxApy`
+    /// @dev `feeSource`, `baseRate`, `optimalUtilRate`, `slope1`, and `slope2`
     constructor(address mathLib_, uint256 maxTotalApy_, uint256 blocksPerYear_, uint16 tradingFee1_, address feeSource_,
-        uint64 baseRate_, uint80 factor_, uint80 maxApy_) CPMMBaseLongStrategy(maxTotalApy_, blocksPerYear_,
-        tradingFee1_, feeSource_, baseRate_, factor_, maxApy_) {
+        uint64 baseRate_, uint64 optimalUtilRate_, uint64 slope1_, uint64 slope2_) CPMMBaseLongStrategy(maxTotalApy_,
+        blocksPerYear_, tradingFee1_, feeSource_, baseRate_, optimalUtilRate_, slope1_, slope2_) {
 
         if(mathLib_ == address(0)) revert MissingMathLib();
         mathLib = mathLib_;

--- a/contracts/strategies/cpmm/base/CPMMBaseRebalanceStrategy.sol
+++ b/contracts/strategies/cpmm/base/CPMMBaseRebalanceStrategy.sol
@@ -18,11 +18,11 @@ abstract contract CPMMBaseRebalanceStrategy is BaseRebalanceStrategy, CPMMBaseLo
     /// @return mathLib - contract containing complex mathematical functions
     address immutable public mathLib;
 
-    /// @dev Initializes the contract by setting `mathLib`, `MAX_TOTAL_APY`, `BLOCKS_PER_YEAR`, `tradingFee1`,
+    /// @dev Initializes the contract by setting `mathLib`, `MAX_TOTAL_APY`, `BLOCKS_PER_YEAR`, `tradingFee1`, `tradingFee2`,
     /// @dev `feeSource`, `baseRate`, `optimalUtilRate`, `slope1`, and `slope2`
-    constructor(address mathLib_, uint256 maxTotalApy_, uint256 blocksPerYear_, uint16 tradingFee1_, address feeSource_,
-        uint64 baseRate_, uint64 optimalUtilRate_, uint64 slope1_, uint64 slope2_) CPMMBaseLongStrategy(maxTotalApy_,
-        blocksPerYear_, tradingFee1_, feeSource_, baseRate_, optimalUtilRate_, slope1_, slope2_) {
+    constructor(address mathLib_, uint256 maxTotalApy_, uint256 blocksPerYear_, uint24 tradingFee1_, uint24 tradingFee2_,
+        address feeSource_, uint64 baseRate_, uint64 optimalUtilRate_, uint64 slope1_, uint64 slope2_) CPMMBaseLongStrategy(maxTotalApy_,
+        blocksPerYear_, tradingFee1_, tradingFee2_, feeSource_, baseRate_, optimalUtilRate_, slope1_, slope2_) {
 
         if(mathLib_ == address(0)) revert MissingMathLib();
         mathLib = mathLib_;
@@ -134,7 +134,7 @@ abstract contract CPMMBaseRebalanceStrategy is BaseRebalanceStrategy, CPMMBaseLo
     /// @param reserve1 - reserve quantity of token1 in CFMM
     /// @return collateral - collateral after transaction in terms of liquidity invariant
     function _calcCollateralPostTradeStaticCall(uint256 preCollateral, uint256 delta, uint128 tokensHeld0, uint128 tokensHeld1, uint256 reserve0, uint256 reserve1) internal virtual view returns(uint256 collateral) {
-        uint16 _tradingFee1 = getTradingFee1();
+        uint256 _tradingFee1 = getTradingFee1();
         uint256 minCollateral = preCollateral * (_tradingFee1 + (tradingFee2 - _tradingFee1) / 2)/ tradingFee2;
 
         // always buys

--- a/contracts/strategies/cpmm/lending/CPMMBorrowStrategy.sol
+++ b/contracts/strategies/cpmm/lending/CPMMBorrowStrategy.sol
@@ -12,10 +12,10 @@ import "../base/CPMMBaseRebalanceStrategy.sol";
 contract CPMMBorrowStrategy is CPMMBaseRebalanceStrategy, BorrowStrategy, RebalanceStrategy {
 
     /// @dev Initializes the contract by setting `mathLib`, `MAX_TOTAL_APY`, `BLOCKS_PER_YEAR`, `tradingFee1`,
-    /// @dev `feeSource_`, `baseRate`, `factor`, and `maxApy`
+    /// @dev `feeSource`, `baseRate`, `optimalUtilRate`, `slope1`, and `slope2`
     constructor(address mathLib_, uint256 maxTotalApy_, uint256 blocksPerYear_, uint16 tradingFee1_, address feeSource_,
-        uint64 baseRate_, uint80 factor_, uint80 maxApy_) CPMMBaseRebalanceStrategy(mathLib_, maxTotalApy_, blocksPerYear_,
-        tradingFee1_, feeSource_, baseRate_, factor_, maxApy_) {
+        uint64 baseRate_, uint64 optimalUtilRate_, uint64 slope1_, uint64 slope2_) CPMMBaseRebalanceStrategy(mathLib_,
+        maxTotalApy_, blocksPerYear_, tradingFee1_, feeSource_, baseRate_, optimalUtilRate_, slope1_, slope2_) {
     }
 
     /// @dev See {BaseBorrowStrategy-getCurrentCFMMPrice}.

--- a/contracts/strategies/cpmm/lending/CPMMBorrowStrategy.sol
+++ b/contracts/strategies/cpmm/lending/CPMMBorrowStrategy.sol
@@ -11,11 +11,11 @@ import "../base/CPMMBaseRebalanceStrategy.sol";
 /// @dev This implementation was specifically designed to work with UniswapV2
 contract CPMMBorrowStrategy is CPMMBaseRebalanceStrategy, BorrowStrategy, RebalanceStrategy {
 
-    /// @dev Initializes the contract by setting `mathLib`, `MAX_TOTAL_APY`, `BLOCKS_PER_YEAR`, `tradingFee1`,
+    /// @dev Initializes the contract by setting `mathLib`, `MAX_TOTAL_APY`, `BLOCKS_PER_YEAR`, `tradingFee1`, `tradingFee2`,
     /// @dev `feeSource`, `baseRate`, `optimalUtilRate`, `slope1`, and `slope2`
-    constructor(address mathLib_, uint256 maxTotalApy_, uint256 blocksPerYear_, uint16 tradingFee1_, address feeSource_,
-        uint64 baseRate_, uint64 optimalUtilRate_, uint64 slope1_, uint64 slope2_) CPMMBaseRebalanceStrategy(mathLib_,
-        maxTotalApy_, blocksPerYear_, tradingFee1_, feeSource_, baseRate_, optimalUtilRate_, slope1_, slope2_) {
+    constructor(address mathLib_, uint256 maxTotalApy_, uint256 blocksPerYear_, uint24 tradingFee1_, uint24 tradingFee2_,
+        address feeSource_, uint64 baseRate_, uint64 optimalUtilRate_, uint64 slope1_, uint64 slope2_) CPMMBaseRebalanceStrategy(mathLib_,
+        maxTotalApy_, blocksPerYear_, tradingFee1_, tradingFee2_, feeSource_, baseRate_, optimalUtilRate_, slope1_, slope2_) {
     }
 
     /// @dev See {BaseBorrowStrategy-getCurrentCFMMPrice}.

--- a/contracts/strategies/cpmm/lending/CPMMRepayStrategy.sol
+++ b/contracts/strategies/cpmm/lending/CPMMRepayStrategy.sol
@@ -11,10 +11,10 @@ import "../base/CPMMBaseRebalanceStrategy.sol";
 contract CPMMRepayStrategy is CPMMBaseRebalanceStrategy, RepayStrategy {
 
 
-    /// @dev Initializes the contract by setting `mathLib`, `MAX_TOTAL_APY`, `BLOCKS_PER_YEAR`,`tradingFee1`,
+    /// @dev Initializes the contract by setting `mathLib`, `MAX_TOTAL_APY`, `BLOCKS_PER_YEAR`,`tradingFee1`, `tradingFee2`,
     /// @dev `feeSource`, `baseRate`, `optimalUtilRate`, `slope1`, and `slope2`
-    constructor(address mathLib_, uint256 maxTotalApy_, uint256 blocksPerYear_, uint16 tradingFee1_, address feeSource_,
-        uint64 baseRate_, uint64 optimalUtilRate_, uint64 slope1_, uint64 slope2_) CPMMBaseRebalanceStrategy(mathLib_,
-        maxTotalApy_, blocksPerYear_, tradingFee1_, feeSource_, baseRate_, optimalUtilRate_, slope1_, slope2_) {
+    constructor(address mathLib_, uint256 maxTotalApy_, uint256 blocksPerYear_, uint24 tradingFee1_, uint24 tradingFee2_,
+        address feeSource_, uint64 baseRate_, uint64 optimalUtilRate_, uint64 slope1_, uint64 slope2_) CPMMBaseRebalanceStrategy(mathLib_,
+        maxTotalApy_, blocksPerYear_, tradingFee1_, tradingFee2_, feeSource_, baseRate_, optimalUtilRate_, slope1_, slope2_) {
     }
 }

--- a/contracts/strategies/cpmm/lending/CPMMRepayStrategy.sol
+++ b/contracts/strategies/cpmm/lending/CPMMRepayStrategy.sol
@@ -12,9 +12,9 @@ contract CPMMRepayStrategy is CPMMBaseRebalanceStrategy, RepayStrategy {
 
 
     /// @dev Initializes the contract by setting `mathLib`, `MAX_TOTAL_APY`, `BLOCKS_PER_YEAR`,`tradingFee1`,
-    /// @dev `feeSource_`, `baseRate`, `factor`, and `maxApy`
+    /// @dev `feeSource`, `baseRate`, `optimalUtilRate`, `slope1`, and `slope2`
     constructor(address mathLib_, uint256 maxTotalApy_, uint256 blocksPerYear_, uint16 tradingFee1_, address feeSource_,
-        uint64 baseRate_, uint80 factor_, uint80 maxApy_) CPMMBaseRebalanceStrategy(mathLib_, maxTotalApy_, blocksPerYear_,
-        tradingFee1_, feeSource_, baseRate_, factor_, maxApy_) {
+        uint64 baseRate_, uint64 optimalUtilRate_, uint64 slope1_, uint64 slope2_) CPMMBaseRebalanceStrategy(mathLib_,
+        maxTotalApy_, blocksPerYear_, tradingFee1_, feeSource_, baseRate_, optimalUtilRate_, slope1_, slope2_) {
     }
 }

--- a/contracts/strategies/cpmm/liquidation/CPMMBatchLiquidationStrategy.sol
+++ b/contracts/strategies/cpmm/liquidation/CPMMBatchLiquidationStrategy.sol
@@ -10,11 +10,11 @@ import "../base/CPMMBaseRebalanceStrategy.sol";
 /// @dev This implementation was specifically designed to work with UniswapV2
 contract CPMMBatchLiquidationStrategy is CPMMBaseRebalanceStrategy, BatchLiquidationStrategy {
 
-    /// @dev Initializes the contract by setting `mathLib`, `MAX_TOTAL_APY`, `BLOCKS_PER_YEAR`, `tradingFee1`, `feeSource`,
-    /// @dev `baseRate`, `optimalUtilRate`, `slope1`, and `slope2`
-    constructor(address mathLib_, uint256 maxTotalApy_, uint256 blocksPerYear_, uint16 tradingFee1_, address feeSource_,
-        uint64 baseRate_, uint64 optimalUtilRate_, uint64 slope1_, uint64 slope2_) CPMMBaseRebalanceStrategy(mathLib_,
-        maxTotalApy_, blocksPerYear_, tradingFee1_, feeSource_, baseRate_, optimalUtilRate_, slope1_, slope2_) {
+    /// @dev Initializes the contract by setting `mathLib`, `MAX_TOTAL_APY`, `BLOCKS_PER_YEAR`, `tradingFee1`, `tradingFee2`,
+    /// @dev `feeSource`, `baseRate`, `optimalUtilRate`, `slope1`, and `slope2`
+    constructor(address mathLib_, uint256 maxTotalApy_, uint256 blocksPerYear_, uint24 tradingFee1_, uint24 tradingFee2_,
+        address feeSource_, uint64 baseRate_, uint64 optimalUtilRate_, uint64 slope1_, uint64 slope2_) CPMMBaseRebalanceStrategy(mathLib_,
+        maxTotalApy_, blocksPerYear_, tradingFee1_, tradingFee2_, feeSource_, baseRate_, optimalUtilRate_, slope1_, slope2_) {
     }
 
     /// @dev See {BatchLiquidationStrategy-_calcMaxCollateralNotMktImpact}.

--- a/contracts/strategies/cpmm/liquidation/CPMMBatchLiquidationStrategy.sol
+++ b/contracts/strategies/cpmm/liquidation/CPMMBatchLiquidationStrategy.sol
@@ -10,11 +10,11 @@ import "../base/CPMMBaseRebalanceStrategy.sol";
 /// @dev This implementation was specifically designed to work with UniswapV2
 contract CPMMBatchLiquidationStrategy is CPMMBaseRebalanceStrategy, BatchLiquidationStrategy {
 
-    /// @dev Initializes the contract by setting `MAX_TOTAL_APY`, `BLOCKS_PER_YEAR`, `tradingFee1`, `feeSource_`,
-    /// @dev `baseRate`, `factor`, and `maxApy`
+    /// @dev Initializes the contract by setting `mathLib`, `MAX_TOTAL_APY`, `BLOCKS_PER_YEAR`, `tradingFee1`, `feeSource`,
+    /// @dev `baseRate`, `optimalUtilRate`, `slope1`, and `slope2`
     constructor(address mathLib_, uint256 maxTotalApy_, uint256 blocksPerYear_, uint16 tradingFee1_, address feeSource_,
-        uint64 baseRate_, uint80 factor_, uint80 maxApy_) CPMMBaseRebalanceStrategy(mathLib_, maxTotalApy_,
-        blocksPerYear_, tradingFee1_, feeSource_, baseRate_, factor_, maxApy_) {
+        uint64 baseRate_, uint64 optimalUtilRate_, uint64 slope1_, uint64 slope2_) CPMMBaseRebalanceStrategy(mathLib_,
+        maxTotalApy_, blocksPerYear_, tradingFee1_, feeSource_, baseRate_, optimalUtilRate_, slope1_, slope2_) {
     }
 
     /// @dev See {BatchLiquidationStrategy-_calcMaxCollateralNotMktImpact}.

--- a/contracts/strategies/cpmm/liquidation/CPMMExternalLiquidationStrategy.sol
+++ b/contracts/strategies/cpmm/liquidation/CPMMExternalLiquidationStrategy.sol
@@ -10,10 +10,10 @@ import "../base/CPMMBaseRebalanceStrategy.sol";
 /// @dev This implementation was specifically designed to work with UniswapV2
 contract CPMMExternalLiquidationStrategy is CPMMBaseRebalanceStrategy, ExternalLiquidationStrategy {
 
-    /// @dev Initializes the contract by setting `mathLib_`,`MAX_TOTAL_APY`, `BLOCKS_PER_YEAR`, `tradingFee1`,
-    /// @dev `feeSource_`, `baseRate`, `factor`, and `maxApy`
+    /// @dev Initializes the contract by setting `mathLib`,`MAX_TOTAL_APY`, `BLOCKS_PER_YEAR`, `tradingFee1`, `feeSource_`,
+    /// @dev `baseRate`, `optimalUtilRate`, `slope1`, and `slope2`
     constructor(address mathLib_, uint256 maxTotalApy_, uint256 blocksPerYear_, uint16 tradingFee1_, address feeSource_,
-        uint64 baseRate_, uint80 factor_, uint80 maxApy_) CPMMBaseRebalanceStrategy(mathLib_, maxTotalApy_, blocksPerYear_,
-        tradingFee1_, feeSource_, baseRate_, factor_, maxApy_) {
+        uint64 baseRate_, uint64 optimalUtilRate_, uint64 slope1_, uint64 slope2_) CPMMBaseRebalanceStrategy(mathLib_,
+        maxTotalApy_, blocksPerYear_, tradingFee1_, feeSource_, baseRate_, optimalUtilRate_, slope1_, slope2_) {
     }
 }

--- a/contracts/strategies/cpmm/liquidation/CPMMExternalLiquidationStrategy.sol
+++ b/contracts/strategies/cpmm/liquidation/CPMMExternalLiquidationStrategy.sol
@@ -10,10 +10,10 @@ import "../base/CPMMBaseRebalanceStrategy.sol";
 /// @dev This implementation was specifically designed to work with UniswapV2
 contract CPMMExternalLiquidationStrategy is CPMMBaseRebalanceStrategy, ExternalLiquidationStrategy {
 
-    /// @dev Initializes the contract by setting `mathLib`,`MAX_TOTAL_APY`, `BLOCKS_PER_YEAR`, `tradingFee1`, `feeSource_`,
-    /// @dev `baseRate`, `optimalUtilRate`, `slope1`, and `slope2`
-    constructor(address mathLib_, uint256 maxTotalApy_, uint256 blocksPerYear_, uint16 tradingFee1_, address feeSource_,
-        uint64 baseRate_, uint64 optimalUtilRate_, uint64 slope1_, uint64 slope2_) CPMMBaseRebalanceStrategy(mathLib_,
-        maxTotalApy_, blocksPerYear_, tradingFee1_, feeSource_, baseRate_, optimalUtilRate_, slope1_, slope2_) {
+    /// @dev Initializes the contract by setting `mathLib`,`MAX_TOTAL_APY`, `BLOCKS_PER_YEAR`, `tradingFee1`, `tradingFee2`,
+    /// @dev `feeSource`, `baseRate`, `optimalUtilRate`, `slope1`, and `slope2`
+    constructor(address mathLib_, uint256 maxTotalApy_, uint256 blocksPerYear_, uint24 tradingFee1_, uint24 tradingFee2_,
+        address feeSource_, uint64 baseRate_, uint64 optimalUtilRate_, uint64 slope1_, uint64 slope2_) CPMMBaseRebalanceStrategy(mathLib_,
+        maxTotalApy_, blocksPerYear_, tradingFee1_, tradingFee2_, feeSource_, baseRate_, optimalUtilRate_, slope1_, slope2_) {
     }
 }

--- a/contracts/strategies/cpmm/liquidation/CPMMLiquidationStrategy.sol
+++ b/contracts/strategies/cpmm/liquidation/CPMMLiquidationStrategy.sol
@@ -10,10 +10,10 @@ import "../base/CPMMBaseRebalanceStrategy.sol";
 /// @dev This implementation was specifically designed to work with UniswapV2
 contract CPMMLiquidationStrategy is CPMMBaseRebalanceStrategy, SingleLiquidationStrategy {
 
-    /// @dev Initializes the contract by setting `MAX_TOTAL_APY`, `BLOCKS_PER_YEAR`, `tradingFee1`, `feeSource_`,
-    /// @dev `baseRate`, `factor`, and `maxApy`
+    /// @dev Initializes the contract by setting `mathLib`, `MAX_TOTAL_APY`, `BLOCKS_PER_YEAR`, `tradingFee1`, `feeSource_`,
+    /// @dev `baseRate`, `optimalUtilRate`, `slope1`, and `slope2`
     constructor(address mathLib_, uint256 maxTotalApy_, uint256 blocksPerYear_, uint16 tradingFee1_, address feeSource_,
-        uint64 baseRate_, uint80 factor_, uint80 maxApy_) CPMMBaseRebalanceStrategy(mathLib_, maxTotalApy_,
-        blocksPerYear_, tradingFee1_, feeSource_, baseRate_, factor_, maxApy_) {
+        uint64 baseRate_, uint64 optimalUtilRate_, uint64 slope1_, uint64 slope2_) CPMMBaseRebalanceStrategy(mathLib_,
+        maxTotalApy_, blocksPerYear_, tradingFee1_, feeSource_, baseRate_, optimalUtilRate_, slope1_, slope2_) {
     }
 }

--- a/contracts/strategies/cpmm/liquidation/CPMMLiquidationStrategy.sol
+++ b/contracts/strategies/cpmm/liquidation/CPMMLiquidationStrategy.sol
@@ -10,10 +10,10 @@ import "../base/CPMMBaseRebalanceStrategy.sol";
 /// @dev This implementation was specifically designed to work with UniswapV2
 contract CPMMLiquidationStrategy is CPMMBaseRebalanceStrategy, SingleLiquidationStrategy {
 
-    /// @dev Initializes the contract by setting `mathLib`, `MAX_TOTAL_APY`, `BLOCKS_PER_YEAR`, `tradingFee1`, `feeSource_`,
-    /// @dev `baseRate`, `optimalUtilRate`, `slope1`, and `slope2`
-    constructor(address mathLib_, uint256 maxTotalApy_, uint256 blocksPerYear_, uint16 tradingFee1_, address feeSource_,
-        uint64 baseRate_, uint64 optimalUtilRate_, uint64 slope1_, uint64 slope2_) CPMMBaseRebalanceStrategy(mathLib_,
-        maxTotalApy_, blocksPerYear_, tradingFee1_, feeSource_, baseRate_, optimalUtilRate_, slope1_, slope2_) {
+    /// @dev Initializes the contract by setting `mathLib`, `MAX_TOTAL_APY`, `BLOCKS_PER_YEAR`, `tradingFee1`, `tradingFee2`,
+    /// @dev `feeSource`, `baseRate`, `optimalUtilRate`, `slope1`, and `slope2`
+    constructor(address mathLib_, uint256 maxTotalApy_, uint256 blocksPerYear_, uint24 tradingFee1_, uint24 tradingFee2_,
+        address feeSource_, uint64 baseRate_, uint64 optimalUtilRate_, uint64 slope1_, uint64 slope2_) CPMMBaseRebalanceStrategy(mathLib_,
+        maxTotalApy_, blocksPerYear_, tradingFee1_, tradingFee2_, feeSource_, baseRate_, optimalUtilRate_, slope1_, slope2_) {
     }
 }

--- a/contracts/strategies/cpmm/rebalance/CPMMExternalRebalanceStrategy.sol
+++ b/contracts/strategies/cpmm/rebalance/CPMMExternalRebalanceStrategy.sol
@@ -10,10 +10,10 @@ import "../base/CPMMBaseLongStrategy.sol";
 /// @dev This implementation was specifically designed to work with UniswapV2
 contract CPMMExternalRebalanceStrategy is CPMMBaseLongStrategy, ExternalRebalanceStrategy {
 
-    /// @dev Initializes the contract by setting `MAX_TOTAL_APY`, `BLOCKS_PER_YEAR`, `tradingFee1`, `feeSource`,
-    /// @dev `baseRate`, `optimalUtilRate`, `slope1`, and `slope2`
-    constructor(uint256 maxTotalApy_, uint256 blocksPerYear_, uint16 tradingFee1_, address feeSource_,
+    /// @dev Initializes the contract by setting `MAX_TOTAL_APY`, `BLOCKS_PER_YEAR`, `tradingFee1`, `tradingFee2`,
+    /// @dev `feeSource`, `baseRate`, `optimalUtilRate`, `slope1`, and `slope2`
+    constructor(uint256 maxTotalApy_, uint256 blocksPerYear_, uint24 tradingFee1_, uint24 tradingFee2_, address feeSource_,
         uint64 baseRate_, uint64 optimalUtilRate_, uint64 slope1_, uint64 slope2_) CPMMBaseLongStrategy(maxTotalApy_,
-        blocksPerYear_, tradingFee1_, feeSource_, baseRate_, optimalUtilRate_, slope1_, slope2_) {
+        blocksPerYear_, tradingFee1_, tradingFee2_, feeSource_, baseRate_, optimalUtilRate_, slope1_, slope2_) {
     }
 }

--- a/contracts/strategies/cpmm/rebalance/CPMMExternalRebalanceStrategy.sol
+++ b/contracts/strategies/cpmm/rebalance/CPMMExternalRebalanceStrategy.sol
@@ -10,10 +10,10 @@ import "../base/CPMMBaseLongStrategy.sol";
 /// @dev This implementation was specifically designed to work with UniswapV2
 contract CPMMExternalRebalanceStrategy is CPMMBaseLongStrategy, ExternalRebalanceStrategy {
 
-    /// @dev Initializes the contract by setting `MAX_TOTAL_APY`, `BLOCKS_PER_YEAR`, `tradingFee1`, `feeSource_`,
-    /// @dev `baseRate`, `factor`, and `maxApy`
+    /// @dev Initializes the contract by setting `MAX_TOTAL_APY`, `BLOCKS_PER_YEAR`, `tradingFee1`, `feeSource`,
+    /// @dev `baseRate`, `optimalUtilRate`, `slope1`, and `slope2`
     constructor(uint256 maxTotalApy_, uint256 blocksPerYear_, uint16 tradingFee1_, address feeSource_,
-        uint64 baseRate_, uint80 factor_, uint80 maxApy_) CPMMBaseLongStrategy(maxTotalApy_, blocksPerYear_,
-        tradingFee1_, feeSource_, baseRate_, factor_, maxApy_) {
+        uint64 baseRate_, uint64 optimalUtilRate_, uint64 slope1_, uint64 slope2_) CPMMBaseLongStrategy(maxTotalApy_,
+        blocksPerYear_, tradingFee1_, feeSource_, baseRate_, optimalUtilRate_, slope1_, slope2_) {
     }
 }

--- a/contracts/test/strategies/cpmm/TestCPMMBaseStrategy.sol
+++ b/contracts/test/strategies/cpmm/TestCPMMBaseStrategy.sol
@@ -10,8 +10,8 @@ contract TestCPMMBaseStrategy is CPMMBaseStrategy {
     event DepositToCFMM(address cfmm, address to, uint256 liquidity);
     event WithdrawFromCFMM(address cfmm, address to, uint256[] amounts);
 
-    constructor(uint64 _baseRate, uint80 _factor, uint80 _maxApy)
-        CPMMBaseStrategy(1e19, 2252571, _baseRate, _factor, _maxApy) {
+    constructor(uint64 _baseRate, uint64 _optimalUtilRate, uint64 _slope1, uint64 _slope2)
+        CPMMBaseStrategy(1e19, 2252571, _baseRate, _optimalUtilRate, _slope1, _slope2) {
     }
 
     function initialize(address cfmm, address[] calldata tokens, uint8[] calldata decimals) external virtual {

--- a/contracts/test/strategies/cpmm/TestCPMMBatchLiquidationStrategy.sol
+++ b/contracts/test/strategies/cpmm/TestCPMMBatchLiquidationStrategy.sol
@@ -14,9 +14,9 @@ contract TestCPMMBatchLiquidationStrategy is CPMMBatchLiquidationStrategy, BaseB
     event ActualOutAmount(uint256 outAmount);
     event CalcAmounts(uint256[] outAmts, uint256[] inAmts);
 
-    constructor(address mathLib_, uint256 maxTotalApy_, uint256 blocksPerYear_, uint16 tradingFee1_, address feeSource_,
-        uint64 baseRate_, uint64 optimalUtilRate_, uint64 slope1_, uint64 slope2_) CPMMBatchLiquidationStrategy(mathLib_,
-        maxTotalApy_, blocksPerYear_, tradingFee1_, feeSource_, baseRate_, optimalUtilRate_, slope1_, slope2_) {
+    constructor(address mathLib_, uint256 maxTotalApy_, uint256 blocksPerYear_, uint24 tradingFee1_, uint24 tradingFee2_,
+        address feeSource_, uint64 baseRate_, uint64 optimalUtilRate_, uint64 slope1_, uint64 slope2_) CPMMBatchLiquidationStrategy(mathLib_,
+        maxTotalApy_, blocksPerYear_, tradingFee1_, tradingFee2_, feeSource_, baseRate_, optimalUtilRate_, slope1_, slope2_) {
     }
 
     function initialize(address factory_, address cfmm_, address[] calldata tokens_, uint8[] calldata decimals_) external virtual {

--- a/contracts/test/strategies/cpmm/TestCPMMBorrowStrategy.sol
+++ b/contracts/test/strategies/cpmm/TestCPMMBorrowStrategy.sol
@@ -18,9 +18,9 @@ contract TestCPMMBorrowStrategy is CPMMBorrowStrategy {
     event ActualOutAmount(uint256 outAmount);
     event CalcAmounts(uint256[] outAmts, uint256[] inAmts);
 
-    constructor(address mathLib_, uint16 tradingFee1_, address feeSource_, uint64 baseRate_, uint64 optimalUtilRate_,
-        uint64 slope1_, uint64 slope2_) CPMMBorrowStrategy(mathLib_, 1e19, 2252571, tradingFee1_, feeSource_, baseRate_,
-        optimalUtilRate_, slope1_, slope2_) {
+    constructor(address mathLib_, uint24 tradingFee1_, uint24 tradingFee2_, address feeSource_, uint64 baseRate_,
+        uint64 optimalUtilRate_, uint64 slope1_, uint64 slope2_) CPMMBorrowStrategy(mathLib_, 1e19, 2252571,
+        tradingFee1_, tradingFee1_, feeSource_, baseRate_, optimalUtilRate_, slope1_, slope2_) {
     }
 
     function initialize(address _factory, address _cfmm, address[] calldata _tokens, uint8[] calldata _decimals) external virtual {

--- a/contracts/test/strategies/cpmm/TestCPMMBorrowStrategy.sol
+++ b/contracts/test/strategies/cpmm/TestCPMMBorrowStrategy.sol
@@ -18,9 +18,9 @@ contract TestCPMMBorrowStrategy is CPMMBorrowStrategy {
     event ActualOutAmount(uint256 outAmount);
     event CalcAmounts(uint256[] outAmts, uint256[] inAmts);
 
-    constructor(address mathLib_, uint16 tradingFee1_, address feeSource_, uint64 baseRate_, uint80 factor_,
-        uint80 maxApy_) CPMMBorrowStrategy(mathLib_, 1e19, 2252571, tradingFee1_, feeSource_, baseRate_,
-        factor_, maxApy_) {
+    constructor(address mathLib_, uint16 tradingFee1_, address feeSource_, uint64 baseRate_, uint64 optimalUtilRate_,
+        uint64 slope1_, uint64 slope2_) CPMMBorrowStrategy(mathLib_, 1e19, 2252571, tradingFee1_, feeSource_, baseRate_,
+        optimalUtilRate_, slope1_, slope2_) {
     }
 
     function initialize(address _factory, address _cfmm, address[] calldata _tokens, uint8[] calldata _decimals) external virtual {

--- a/contracts/test/strategies/cpmm/TestCPMMExternalRebalanceStrategy.sol
+++ b/contracts/test/strategies/cpmm/TestCPMMExternalRebalanceStrategy.sol
@@ -18,8 +18,8 @@ contract TestCPMMExternalRebalanceStrategy is CPMMExternalRebalanceStrategy {
     event ActualOutAmount(uint256 outAmount);
     event CalcAmounts(uint256[] outAmts, uint256[] inAmts);
 
-    constructor(uint16 tradingFee1_, address feeSource_, uint64 baseRate_, uint80 factor_, uint80 maxApy_)
-        CPMMExternalRebalanceStrategy(1e19, 2252571, tradingFee1_, feeSource_, baseRate_, factor_, maxApy_) {
+    constructor(uint16 tradingFee1_, address feeSource_, uint64 baseRate_, uint64 optimalUtilRate_, uint64 slope1_, uint64 slope2_)
+        CPMMExternalRebalanceStrategy(1e19, 2252571, tradingFee1_, feeSource_, baseRate_, optimalUtilRate_, slope1_, slope2_) {
     }
 
     function initialize(address _factory, address _cfmm, address[] calldata _tokens, uint8[] calldata _decimals) external virtual {

--- a/contracts/test/strategies/cpmm/TestCPMMExternalRebalanceStrategy.sol
+++ b/contracts/test/strategies/cpmm/TestCPMMExternalRebalanceStrategy.sol
@@ -18,8 +18,9 @@ contract TestCPMMExternalRebalanceStrategy is CPMMExternalRebalanceStrategy {
     event ActualOutAmount(uint256 outAmount);
     event CalcAmounts(uint256[] outAmts, uint256[] inAmts);
 
-    constructor(uint16 tradingFee1_, address feeSource_, uint64 baseRate_, uint64 optimalUtilRate_, uint64 slope1_, uint64 slope2_)
-        CPMMExternalRebalanceStrategy(1e19, 2252571, tradingFee1_, feeSource_, baseRate_, optimalUtilRate_, slope1_, slope2_) {
+    constructor(uint24 tradingFee1_, uint24 tradingFee2_, address feeSource_, uint64 baseRate_, uint64 optimalUtilRate_,
+        uint64 slope1_, uint64 slope2_) CPMMExternalRebalanceStrategy(1e19, 2252571, tradingFee1_, tradingFee2_,
+        feeSource_, baseRate_, optimalUtilRate_, slope1_, slope2_) {
     }
 
     function initialize(address _factory, address _cfmm, address[] calldata _tokens, uint8[] calldata _decimals) external virtual {

--- a/contracts/test/strategies/cpmm/TestCPMMLiquidationStrategy.sol
+++ b/contracts/test/strategies/cpmm/TestCPMMLiquidationStrategy.sol
@@ -12,9 +12,9 @@ contract TestCPMMLiquidationStrategy is CPMMLiquidationStrategy, BaseBorrowStrat
 
     event LoanCreated(address indexed caller, uint256 tokenId);
 
-    constructor(address mathLib_, uint256 maxTotalApy_, uint256 blocksPerYear_, uint16 tradingFee1_, address feeSource_,
-        uint64 baseRate_, uint64 optimalUtilRate_, uint64 slope1_, uint64 slope2_) CPMMLiquidationStrategy(mathLib_,
-        maxTotalApy_, blocksPerYear_, tradingFee1_, feeSource_, baseRate_, optimalUtilRate_, slope1_, slope2_) {
+    constructor(address mathLib_, uint256 maxTotalApy_, uint256 blocksPerYear_, uint24 tradingFee1_, uint24 tradingFee2_,
+        address feeSource_, uint64 baseRate_, uint64 optimalUtilRate_, uint64 slope1_, uint64 slope2_) CPMMLiquidationStrategy(mathLib_,
+        maxTotalApy_, blocksPerYear_, tradingFee1_, tradingFee2_, feeSource_, baseRate_, optimalUtilRate_, slope1_, slope2_) {
     }
 
     function _calcOriginationFee(uint256 liquidityBorrowed, uint256 borrowedInvariant, uint256 lpInvariant, uint256 lowUtilRate, uint256 discount) internal virtual override view returns(uint256 origFee) {

--- a/contracts/test/strategies/cpmm/TestCPMMLiquidationStrategy.sol
+++ b/contracts/test/strategies/cpmm/TestCPMMLiquidationStrategy.sol
@@ -13,8 +13,8 @@ contract TestCPMMLiquidationStrategy is CPMMLiquidationStrategy, BaseBorrowStrat
     event LoanCreated(address indexed caller, uint256 tokenId);
 
     constructor(address mathLib_, uint256 maxTotalApy_, uint256 blocksPerYear_, uint16 tradingFee1_, address feeSource_,
-        uint64 baseRate_, uint80 factor_, uint80 maxApy_) CPMMLiquidationStrategy(mathLib_, maxTotalApy_, blocksPerYear_,
-        tradingFee1_, feeSource_, baseRate_, factor_, maxApy_) {
+        uint64 baseRate_, uint64 optimalUtilRate_, uint64 slope1_, uint64 slope2_) CPMMLiquidationStrategy(mathLib_,
+        maxTotalApy_, blocksPerYear_, tradingFee1_, feeSource_, baseRate_, optimalUtilRate_, slope1_, slope2_) {
     }
 
     function _calcOriginationFee(uint256 liquidityBorrowed, uint256 borrowedInvariant, uint256 lpInvariant, uint256 lowUtilRate, uint256 discount) internal virtual override view returns(uint256 origFee) {
@@ -86,8 +86,8 @@ contract TestCPMMLiquidationStrategy is CPMMLiquidationStrategy, BaseBorrowStrat
         s.LP_INVARIANT = lpInvariant;
     }
 
-    function calcBorrowRate(uint256, uint256, address, address) public override(AbstractRateModel, LogDerivativeRateModel) virtual view returns(uint256,uint256) {
-        return (1e19,1e19);
+    function calcBorrowRate(uint256, uint256, address, address) public override(AbstractRateModel, LinearKinkedRateModel) virtual view returns(uint256,uint256,uint256,uint256) {
+        return (1e19,1e19,5000,1e18);
     }
 
     /// @dev See {BaseLongStrategy-getCurrentCFMMPrice}.

--- a/contracts/test/strategies/cpmm/TestCPMMLiquidationWithLPStrategy.sol
+++ b/contracts/test/strategies/cpmm/TestCPMMLiquidationWithLPStrategy.sol
@@ -14,9 +14,9 @@ contract TestCPMMLiquidationWithLPStrategy is CPMMLiquidationStrategy, BaseBorro
     event ActualOutAmount(uint256 outAmount);
     event CalcAmounts(uint256[] outAmts, uint256[] inAmts);
 
-    constructor(address mathLib_, uint256 maxTotalApy_, uint256 blocksPerYear_, uint16 tradingFee1_, address feeSource_,
-        uint64 baseRate_, uint64 optimalUtilRate_, uint64 slope1_, uint64 slope2_) CPMMLiquidationStrategy(mathLib_,
-        maxTotalApy_, blocksPerYear_, tradingFee1_, feeSource_, baseRate_, optimalUtilRate_, slope1_, slope2_) {
+    constructor(address mathLib_, uint256 maxTotalApy_, uint256 blocksPerYear_, uint24 tradingFee1_, uint24 tradingFee2_,
+        address feeSource_, uint64 baseRate_, uint64 optimalUtilRate_, uint64 slope1_, uint64 slope2_) CPMMLiquidationStrategy(mathLib_,
+        maxTotalApy_, blocksPerYear_, tradingFee1_, tradingFee2_, feeSource_, baseRate_, optimalUtilRate_, slope1_, slope2_) {
     }
 
     function setPoolParams(uint8 liquidationFee, uint8 ltvThreshold) external virtual {

--- a/contracts/test/strategies/cpmm/TestCPMMLiquidationWithLPStrategy.sol
+++ b/contracts/test/strategies/cpmm/TestCPMMLiquidationWithLPStrategy.sol
@@ -15,8 +15,8 @@ contract TestCPMMLiquidationWithLPStrategy is CPMMLiquidationStrategy, BaseBorro
     event CalcAmounts(uint256[] outAmts, uint256[] inAmts);
 
     constructor(address mathLib_, uint256 maxTotalApy_, uint256 blocksPerYear_, uint16 tradingFee1_, address feeSource_,
-        uint64 baseRate_, uint80 factor_, uint80 maxApy_) CPMMLiquidationStrategy(mathLib_, maxTotalApy_, blocksPerYear_,
-        tradingFee1_, feeSource_, baseRate_, factor_, maxApy_) {
+        uint64 baseRate_, uint64 optimalUtilRate_, uint64 slope1_, uint64 slope2_) CPMMLiquidationStrategy(mathLib_,
+        maxTotalApy_, blocksPerYear_, tradingFee1_, feeSource_, baseRate_, optimalUtilRate_, slope1_, slope2_) {
     }
 
     function setPoolParams(uint8 liquidationFee, uint8 ltvThreshold) external virtual {
@@ -99,8 +99,8 @@ contract TestCPMMLiquidationWithLPStrategy is CPMMLiquidationStrategy, BaseBorro
         updateLoan(s.loans[tokenId]);
     }
 
-    function calcBorrowRate(uint256, uint256, address, address) public override(AbstractRateModel, LogDerivativeRateModel) virtual view returns(uint256,uint256) {
-        return (1e19,1e19);
+    function calcBorrowRate(uint256, uint256, address, address) public override(AbstractRateModel, LinearKinkedRateModel) virtual view returns(uint256,uint256,uint256,uint256) {
+        return (1e19,1e19,5000,1e18);
     }
 
     function _borrowLiquidity(uint256 tokenId, uint256 lpTokens, uint256[] calldata ratio) external virtual returns(uint256 liquidityBorrowed, uint256[] memory amounts) {

--- a/contracts/test/strategies/cpmm/TestCPMMRepayStrategy.sol
+++ b/contracts/test/strategies/cpmm/TestCPMMRepayStrategy.sol
@@ -10,8 +10,9 @@ contract TestCPMMRepayStrategy is CPMMRepayStrategy, BorrowStrategy {
 
     event LoanCreated(address indexed caller, uint256 tokenId);
 
-    constructor(address mathLib_, uint16 tradingFee1_, address feeSource_, uint64 baseRate_, uint80 factor_, uint80 maxApy_)
-        CPMMRepayStrategy(mathLib_, 1e19, 2252571, tradingFee1_, feeSource_, baseRate_, factor_, maxApy_) {
+    constructor(address mathLib_, uint16 tradingFee1_, address feeSource_, uint64 baseRate_, uint64 optimalUtilRate_,
+        uint64 slope1_, uint64 slope2_) CPMMRepayStrategy(mathLib_, 1e19, 2252571, tradingFee1_, feeSource_, baseRate_,
+        optimalUtilRate_, slope1_, slope2_) {
     }
 
     function initialize(address _factory, address _cfmm, address[] calldata _tokens, uint8[] calldata _decimals) external virtual {

--- a/contracts/test/strategies/cpmm/TestCPMMRepayStrategy.sol
+++ b/contracts/test/strategies/cpmm/TestCPMMRepayStrategy.sol
@@ -10,9 +10,9 @@ contract TestCPMMRepayStrategy is CPMMRepayStrategy, BorrowStrategy {
 
     event LoanCreated(address indexed caller, uint256 tokenId);
 
-    constructor(address mathLib_, uint16 tradingFee1_, address feeSource_, uint64 baseRate_, uint64 optimalUtilRate_,
-        uint64 slope1_, uint64 slope2_) CPMMRepayStrategy(mathLib_, 1e19, 2252571, tradingFee1_, feeSource_, baseRate_,
-        optimalUtilRate_, slope1_, slope2_) {
+    constructor(address mathLib_, uint16 tradingFee1_, uint24 tradingFee2_, address feeSource_, uint64 baseRate_,
+        uint64 optimalUtilRate_, uint64 slope1_, uint64 slope2_) CPMMRepayStrategy(mathLib_, 1e19, 2252571,
+        tradingFee1_, tradingFee2_, feeSource_, baseRate_, optimalUtilRate_, slope1_, slope2_) {
     }
 
     function initialize(address _factory, address _cfmm, address[] calldata _tokens, uint8[] calldata _decimals) external virtual {

--- a/contracts/test/strategies/cpmm/TestCPMMShortStrategy.sol
+++ b/contracts/test/strategies/cpmm/TestCPMMShortStrategy.sol
@@ -7,8 +7,8 @@ contract TestCPMMShortStrategy is CPMMShortStrategy {
 
     using LibStorage for LibStorage.Storage;
 
-    constructor(uint64 _baseRate, uint80 _factor, uint80 _maxApy)
-        CPMMShortStrategy(1e19, 2252571, _baseRate, _factor, _maxApy) {
+    constructor(uint64 _baseRate, uint64 _optimalUtilRate, uint64 _slope1, uint64 _slope2)
+        CPMMShortStrategy(1e19, 2252571, _baseRate, _optimalUtilRate, _slope1, _slope2) {
     }
 
     function initialize(address cfmm, address[] calldata tokens, uint8[] calldata decimals) external virtual {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gammaswap/v1-implementations",
-  "version": "1.1.32",
+  "version": "1.2.0",
   "description": "Pool and strategies implementation contracts for GammaSwap V1 protocol",
   "homepage": "https://gammaswap.com",
   "scripts": {
@@ -71,7 +71,7 @@
     "typescript": "^4.7.4"
   },
   "dependencies": {
-    "@gammaswap/v1-core": "^1.1.27",
+    "@gammaswap/v1-core": "^1.2.1",
     "@openzeppelin/contracts": "^4.7.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -449,10 +449,10 @@
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
 
-"@gammaswap/v1-core@^1.1.27":
-  version "1.1.27"
-  resolved "https://npm.pkg.github.com/download/@gammaswap/v1-core/1.1.27/58e6196c4946a5808628254ecd3d52a09065624d#58e6196c4946a5808628254ecd3d52a09065624d"
-  integrity sha512-+Y2pD4j01a6n8QUPRyaIGGuhu4O+U5AfMrki/FYxWHey00S/V2hhimcfTkkS1lcmd95pBYmmOxcmNYpX5MU1og==
+"@gammaswap/v1-core@^1.2.1":
+  version "1.2.1"
+  resolved "https://npm.pkg.github.com/download/@gammaswap/v1-core/1.2.1/c5a65f759c77ba9f03e3ab86376771bec1edc2d5#c5a65f759c77ba9f03e3ab86376771bec1edc2d5"
+  integrity sha512-xTraMCQS0W4ZCU0e3v1mCdJ5PkLFdR2d3SAthgZ8DYpmiHe0QjJrgStfRl+I1UprgPlVp0qQygzFiaSeZXGYzQ==
   dependencies:
     "@openzeppelin/contracts" "^4.7.0"
 


### PR DESCRIPTION
-update v1-core to 1.2.1
-change CPMMGammaPool from using LogDerivativeRateModel to LinearKinkedRateModel
-add tradingFee2 to constructors of long strategies
-update unit tests

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206744782968333