### PR TITLE
Fix: Pausing loan creation

### DIFF
--- a/contracts/pools/CPMMGammaPool.sol
+++ b/contracts/pools/CPMMGammaPool.sol
@@ -37,7 +37,7 @@ contract CPMMGammaPool is GammaPool, GammaPoolExternal {
     }
 
     /// @dev See {IGammaPool-createLoan}
-    function createLoan(uint16 refId) external lock virtual override returns(uint256 tokenId) {
+    function createLoan(uint16 refId) external lock virtual override whenNotPaused(9) returns(uint256 tokenId) {
         tokenId = s.createLoan(2, refId); // only 2 token pair
         emit LoanCreated(msg.sender, tokenId, refId);
     }


### PR DESCRIPTION
The function `createLoan(uint16 refId)` in *GammaPool.sol* contains a modifier "`whenNotPaused(9)`" allowing developers to pause loan creation if required in a critical situation.

```javascript
    /// @dev See {IGammaPool-createLoan}
    function createLoan(uint16 refId) external lock virtual override whenNotPaused(9) returns(uint256 tokenId) {
        tokenId = s.createLoan(s.tokens.length, refId);
        emit LoanCreated(msg.sender, tokenId, refId);
    }
```
> *GammaPool.sol*

The *CPMMGammaPool.sol* smart contract, which inherits *GammaPool.sol*, overrides the `createLoan(uint16 refId)` function hardcoding to **2** the number of tokens the loan is for.

```javascript
    /// @dev See {IGammaPool-createLoan}
    function createLoan(uint16 refId) external lock virtual override returns(uint256 tokenId) {
        tokenId = s.createLoan(2, refId); // only 2 token pair
        emit LoanCreated(msg.sender, tokenId, refId);
    }
```
> *CPMMGammaPool.sol*

We correctly added the reentrancy `lock` modifier but unfortunately, forgot to add the `whenNotPaused(9)` modifier.

As a result, loan creation can't be paused in a CPMM Gammaswap Pool.

This pull request adds back the `whenNotPaused(9)` modifier to the `createLoan(uint16 refId)` function in the *CPMMGammaPool.sol* smart contract, allowing developers to pause new loan creations if necessary.